### PR TITLE
MOEX: Filters data from the main board

### DIFF
--- a/pandas_datareader/moex.py
+++ b/pandas_datareader/moex.py
@@ -102,6 +102,7 @@ class MoexReader(_DailyBaseReader):
         """Get markets and engines for the given symbols"""
 
         markets_n_engines = {}
+        boards = {}
 
         for symbol in self.symbols:
             response = self._get_response(self.__url_metadata.format(symbol=symbol))
@@ -130,6 +131,11 @@ class MoexReader(_DailyBaseReader):
                     markets_n_engines[symbol].append(
                         (fields[5], fields[7])
                     )  # market and engine
+
+                    if fields[14] == "1":  # main board for symbol
+                        symbol = symbol.upper()
+                        boards[symbol] = fields[1]
+
             if symbol not in markets_n_engines:
                 raise IOError(
                     "{} request returned no metadata: {}\n"
@@ -141,13 +147,14 @@ class MoexReader(_DailyBaseReader):
                 )
             if symbol in markets_n_engines:
                 markets_n_engines[symbol] = list(set(markets_n_engines[symbol]))
-        return markets_n_engines
+        return markets_n_engines, boards
 
     def read(self):
         """Read data"""
 
+        markets_n_engines, boards = self._get_metadata()
         try:
-            self.__markets_n_engines = self._get_metadata()
+            self.__markets_n_engines = markets_n_engines
 
             urls = self.url  # generate urls per symbols
             dfs = []  # an array of pandas dataframes per symbol to concatenate
@@ -198,9 +205,16 @@ class MoexReader(_DailyBaseReader):
                 "check URL or correct a date".format(self.__class__.__name__)
             )
         elif len(dfs) > 1:
-            return concat(dfs, axis=0, join="outer", sort=True)
+            b = concat(dfs, axis=0, join="outer", sort=True)
         else:
-            return dfs[0]
+            b = dfs[0]
+
+        result = pd.DataFrame()
+        for secid in list(set(b["SECID"].tolist())):
+            part = b[b["BOARDID"] == boards[secid]]
+            result = result.append(part)
+        result = result.drop_duplicates()
+        return result
 
     def _read_url_as_String(self, url, params=None):
         """Open an url (and retry)"""

--- a/pandas_datareader/tests/test_moex.py
+++ b/pandas_datareader/tests/test_moex.py
@@ -21,6 +21,13 @@ class TestMoex(object):
             df = web.DataReader(
                 ["GAZP", "SIBN"], "moex", start="2019-12-26", end="2019-12-26"
             )
-            assert df.size == 740
+            assert df.size == 74
+        except HTTPError as e:
+            pytest.skip(e)
+
+    def test_moex_datareader_filter(self):
+        try:
+            df = web.DataReader("SBER", "moex", start="2020-07-14", end="2020-07-14")
+            assert len(df) == 1
         except HTTPError as e:
             pytest.skip(e)


### PR DESCRIPTION
- [X] closes #811 and #748
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt

Filters output using only data from the main board for every ticker (before that it returned unuseful stats from repo boards and null values from boards, that were not main for the asset).
